### PR TITLE
add bower components to gitignore

### DIFF
--- a/starter-code/.gitignore
+++ b/starter-code/.gitignore
@@ -25,6 +25,7 @@ build/Release
 # Dependency directory
 # https://docs.npmjs.com/cli/shrinkwrap#caveats
 node_modules
+bower_components
 
 # Debug log from npm
 npm-debug.log


### PR DESCRIPTION
Avoids the addition of the bower_components directory when they do `git add .`, making easier to correct their PRs